### PR TITLE
ci: bump to deno v1.6.1 and add test script to ci steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
       - name: download deno
         uses: denolib/setup-deno@v2
         with:
-          deno-version: v1.5.2
+          deno-version: v1.6.1
+      - name: test
+        run: deno test test 
       - name: check format
         if: matrix.os == 'ubuntu-latest'
         run: deno fmt --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           deno-version: v1.6.1
       - name: test
-        run: deno test test 
+        run: deno test 
       - name: check format
         if: matrix.os == 'ubuntu-latest'
         run: deno fmt --check


### PR DESCRIPTION
1. update the deno version to `v1.6.1`
2. add test script to ci steps